### PR TITLE
ignore yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ yarn-error.log
 
 # package lock
 package-lock.json
+yarn.lock


### PR DESCRIPTION
If we're not gonna have yarn.lock file in remote repo, need to ignore it because the yarn.lock file dirties my repo and it is distracting.