### PR TITLE
add to test set up

### DIFF
--- a/__mocks__/file-mock.js
+++ b/__mocks__/file-mock.js
@@ -1,0 +1,1 @@
+module.exports = "test-file-stub"

--- a/__mocks__/gatsby.js
+++ b/__mocks__/gatsby.js
@@ -1,0 +1,26 @@
+const React = require('react');
+const gatsby = jest.requireActual('gatsby');
+
+module.exports = {
+  ...gatsby,
+  graphql: jest.fn(),
+  Link: jest.fn().mockImplementation(
+    // these props are invalid for an `a` tag
+    ({
+      activeClassName,
+      activeStyle,
+      getProps,
+      innerRef,
+      ref,
+      replace,
+      to,
+      ...rest
+    }) =>
+      React.createElement('a', {
+        ...rest,
+        href: to
+      })
+  ),
+  StaticQuery: jest.fn(),
+  useStaticQuery: jest.fn()
+};

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,6 +12,11 @@ module.exports = {
         name: `images`,
         path: `${__dirname}/src/images`,
       },
+    },{
+      resolve: `gatsby-plugin-emotion`,
+      options: {
+        // Accepts all options defined by `babel-plugin-emotion` plugin.
+      },
     },
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,

--- a/jest-preprocess.js
+++ b/jest-preprocess.js
@@ -1,0 +1,6 @@
+const babelOptions = {
+  presets: ['babel-preset-gatsby'],
+  plugins: ["emotion"]
+};
+
+module.exports = require('babel-jest').createTransformer(babelOptions);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,19 @@
 module.exports = {
+  transform: {
+    "^.+\\.jsx?$": `<rootDir>/jest-preprocess.js`,
+  },
+  moduleNameMapper: {
+    ".+\\.(css|styl|less|sass|scss)$": `identity-obj-proxy`,
+    ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": `<rootDir>/__mocks__/file-mock.js`,
+  },
   verbose: true,
   setupFilesAfterEnv: ['react-testing-library/cleanup-after-each'],
   testMatch: ['**/?(*.)+(spec).js?(x)'],
   testPathIgnorePatterns: ['/node_modules/', '/.cache/'],
+  transformIgnorePatterns: [`node_modules/(?!(gatsby)/)`],
+  globals: {
+    __PATH_PREFIX__: ``,
+  },
+  setupFiles: [`<rootDir>/loadershim.js`],
   moduleDirectories: ['node_modules']
 };

--- a/loadershim.js
+++ b/loadershim.js
@@ -1,0 +1,3 @@
+global.___loader = {
+  enqueue: jest.fn(),
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "classnames": "^2.2.6",
     "gatsby": "^2.4.1",
     "gatsby-image": "^2.0.41",
+    "gatsby-plugin-emotion": "^4.0.6",
     "gatsby-plugin-manifest": "^2.1.1",
     "gatsby-plugin-offline": "^2.1.0",
     "gatsby-plugin-react-helmet": "^3.0.12",
@@ -29,7 +30,12 @@
     "@babel/preset-react": "^7.0.0",
     "@storybook/react": "^5.0.11",
     "babel-jest": "^24.8.0",
+    "babel-plugin-emotion": "^10.0.9",
+    "babel-preset-gatsby": "^0.1.11",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^24.8.0",
+    "jest-dom": "^3.2.2",
+    "jest-emotion": "^10.0.11",
     "jsdom": "^15.0.0",
     "jsdom-global": "^3.0.2",
     "prettier": "^1.17.0",
@@ -53,6 +59,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby-starter-default"
+  },
+  "jest": {
+    "setupTestFrameworkScriptFile": "<rootDir>/setup-test-env.js"
   },
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/setup-test-env.js
+++ b/setup-test-env.js
@@ -1,0 +1,8 @@
+import { createSerializer } from "jest-emotion"
+import * as emotion from "emotion"
+
+import "jest-dom/extend-expect"
+import "react-testing-library/cleanup-after-each"
+// this is basically: afterEach(cleanup)
+
+expect.addSnapshotSerializer(createSerializer(emotion))

--- a/src/components/atoms/hero/components/__snapshots__/Hero.spec.js.snap
+++ b/src/components/atoms/hero/components/__snapshots__/Hero.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Hero snapshot tests renders with custom props 1`] = `
 <div
-  class="css-8jgnfd"
+  class="css-wit2t5-HeroImage e1blgcp90"
   data-testid="some-testid"
 >
   <div
@@ -13,7 +13,7 @@ exports[`Hero snapshot tests renders with custom props 1`] = `
 
 exports[`Hero snapshot tests renders with default props 1`] = `
 <div
-  class="css-1gcj3ef"
+  class="css-1riqis2-HeroImage e1blgcp90"
   data-testid="hero-atom"
 />
 `;


### PR DESCRIPTION
links to #8 
Adds to the test set up to allow for direct testing of styles in styled components.

# DO NOT MERGE
Currently Ross' hero snapshot tests have been broken. Although these might be able to be replaced with new functionality